### PR TITLE
WIP: Add getStream

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -367,6 +367,17 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
 
         return this.clone(File, "$value", false).usingParser(new BufferParser())(headers({ "binaryStringResponseBody": "true" }));
     }
+    
+    /**
+     * Gets the contents of a Node Stream, works ONLY in Node.js. Not supported in batching.
+     */
+    @tag("fi.getStream")
+    public getStream(): Promise<ArrayBuffer> {
+
+        return this.clone(File, "$value", false).usingParser({ parse(r) {
+            return Promise.resolve(r.body)
+        }})(headers({ "binaryStringResponseBody": "true" }));
+    }
 
     /**
      * Gets the contents of a file as an ArrayBuffer, works in Node.js. Not supported in batching.


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?


#### What's in this Pull Request?

I had to put a lot of research in to figure out how to get a stream instead of loading the whole thing into memory.
Without reading the code of getBlob I wouldn't be able to do it.
This is a WIP to check if the contribution like this is welcome.

I'm aware the parser would need to go to the odata package and inherit properly.
I'm aware docs would follow.

It seemed odd this method is not there yet, so I'm checking if there wasn't a reason behind it.

Please comment.